### PR TITLE
Update Go version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM bitriseio/bitrise-base-20.04:latest
 
-ENV GO_VERSION=1.15.15 \
+ENV GO_VERSION=1.18.5 \
     TERRAFORM_VERSION=0.15.5 \
     GCLOUD_VERSION=394.0.0 \
     # overriding GOPATH so we'll preserve pre-installed packages
@@ -20,8 +20,8 @@ ENV PATH=$GOBIN:$PATH:/usr/local/google-cloud-sdk/bin
 
 # install go dependencies
 RUN mkdir -p $GOPATH \
-    && go get -u github.com/kisielk/errcheck \
-    && go get -u golang.org/x/lint/golint
+    && go install github.com/kisielk/errcheck \
+    && go install golang.org/x/lint/golint
 
 RUN wget 'https://github.com/aquasecurity/tfsec/releases/download/v1.26.3/tfsec-linux-amd64' -O /usr/local/bin/tfsec && chmod +x /usr/local/bin/tfsec
 


### PR DESCRIPTION
* Update to a supported Go version.
* To install binaries, must use go install path@version. go get is no longer supported.